### PR TITLE
Add HTTP config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ If `jenkins_url` is supplied then this file will be written to. If `jenkins_url`
 
 defaults to: `$HOME/.cache/nvim/cmp-jenkinsfile.gdsl`
 
+**http**: optional http configuration
+- **basic_auth_user**: username for basic authentication
+- **basic_auth_password**: password for basic authentication
+- **ca_cert**: path to CA certificate file
+- **proxy**: proxy URL
 
 **Recommended Config:**
 
@@ -38,6 +43,29 @@ cmp.setup({
         name = "jenkinsfile",
         option = {
           jenkins_url = "https://jenkins.co",
+        },
+      },
+    },
+  }),
+```
+
+**Full Config:**
+
+```lua
+cmp.setup({
+  cmp.setup.filetype("Jenkinsfile", {
+    sources = {
+      {
+        name = "jenkinsfile",
+        option = {
+          jenkins_url = "https://jenkins.co",
+          gdsl_file = "~/.cache/nvim/cmp-jenkinsfile.gdsl",
+          http = {
+            http_basic_user = "admin",
+            http_basic_password = "adminadmin",
+            ca_cert = "/etc/ssl/certs/cacert",
+            proxy = "http://internal-proxy:8000",
+          },
         },
       },
     },

--- a/lua/cmp_jenkins/init.lua
+++ b/lua/cmp_jenkins/init.lua
@@ -47,10 +47,10 @@ function source:complete(params, callback)
   vim.validate('gdsl_file', params.option.gdsl_file, 'string', false, '`opts.gdsl_file` must be `string`')
   vim.validate('jenkins_url', params.option.jenkins_url, 'string', false, '`opts.jenkins_url` must be `string`')
   vim.validate('http', params.option.http, 'table', false, '`opts.http` must be `table`')
-  vim.validate('http.basic_auth_user', params.option.http.basic_auth_user, 'string', false, '`http.basic_auth_user` must be `string`')
-  vim.validate('http.basic_auth_password', params.option.http.basic_auth_password, 'string', false, '`http.basic_auth_password` must be `string`')
-  vim.validate('http.ca_cert', params.option.http.ca_cert, 'string', false, '`http.ca_cert` must be `string`')
-  vim.validate('http.proxy', params.option.http.proxy, 'string', false, '`http.proxy` must be `string`')
+  vim.validate('http.basic_auth_user', params.option.http.basic_auth_user, 'string', false, '`opts.http.basic_auth_user` must be `string`')
+  vim.validate('http.basic_auth_password', params.option.http.basic_auth_password, 'string', false, '`opts.http.basic_auth_password` must be `string`')
+  vim.validate('http.ca_cert', params.option.http.ca_cert, 'string', false, '`opts.http.ca_cert` must be `string`')
+  vim.validate('http.proxy', params.option.http.proxy, 'string', false, '`opts.http.proxy` must be `string`')
 
   if params.option.jenkins_url ~= "" then
     if not file_exists(params.option.gdsl_file) or file_is_empty(params.option.gdsl_file) then

--- a/lua/cmp_jenkins/init.lua
+++ b/lua/cmp_jenkins/init.lua
@@ -56,7 +56,7 @@ function source:complete(params, callback)
     if not file_exists(params.option.gdsl_file) or file_is_empty(params.option.gdsl_file) then
       local curl_cmd = build_curl(params.option.jenkins_url, params.option.http)
       local handle = io.popen(curl_cmd.." > "..params.option.gdsl_file)
-     if handle ~= nil then
+      if handle ~= nil then
         local result = handle:read("*a")
         print(result)
         handle:close()

--- a/lua/cmp_jenkins/init.lua
+++ b/lua/cmp_jenkins/init.lua
@@ -11,12 +11,12 @@ local defaults = {
   },
 }
 
-function file_exists(name)
+local function file_exists(name)
   local f=io.open(name,"r")
   if f~=nil then io.close(f) return true else return false end
 end
 
-function file_is_empty(name)
+local function file_is_empty(name)
   local file = io.open(name,"r")
   if not file then return true end
   local content = file:read "*a"
@@ -24,8 +24,8 @@ function file_is_empty(name)
   return res == nil
 end
 
-function build_curl(jenkins_url, opts)
-    local cmd = "curl -X GET "..jenkins_url.."/pipeline-syntax/gdsl"
+local function build_curl(jenkins_url, opts)
+    local cmd = "curl --silent -X GET "..jenkins_url.."/pipeline-syntax/gdsl"
     if opts.proxy ~= "" then
         cmd = cmd.." --proxy "..opts.proxy
     end
@@ -56,15 +56,16 @@ function source:complete(params, callback)
     if not file_exists(params.option.gdsl_file) or file_is_empty(params.option.gdsl_file) then
       local curl_cmd = build_curl(params.option.jenkins_url, params.option.http)
       local handle = io.popen(curl_cmd.." > "..params.option.gdsl_file)
-      local result = handle:read("*a")
-      print(result)
-      handle:close()
+     if handle ~= nil then
+        local result = handle:read("*a")
+        print(result)
+        handle:close()
+      end
     end
   end
 
   local _vals = {}
   local items = {}
-  local last_item
   local file = io.open(params.option.gdsl_file)
   if file ~= nil then
 

--- a/lua/cmp_jenkins/init.lua
+++ b/lua/cmp_jenkins/init.lua
@@ -25,10 +25,8 @@ end
 
 function source:complete(params, callback)
   params.option = vim.tbl_deep_extend('keep', params.option, defaults)
-  vim.validate({
-      gdsl_file = { params.option.gdsl_file, 'string', '`opts.gdsl_file` must be `string`' },
-      jenkins_url = { params.option.jenkins_url, 'string', '`opts.jenkins_url` must be `string`' },
-    })
+  vim.validate('gdsl_file', params.option.gdsl_file, 'string', false, '`opts.gdsl_file` must be `string`')
+  vim.validate('jenkins_url', params.option.jenkins_url, 'string', false, '`opts.jenkins_url` must be `string`')
   if params.option.jenkins_url ~= "" then
     if not file_exists(params.option.gdsl_file) or file_is_empty(params.option.gdsl_file) then
       local handle = io.popen("curl -s -X GET "..params.option.jenkins_url.."/pipeline-syntax/gdsl".." > "..params.option.gdsl_file)


### PR DESCRIPTION
Adds options for HTTP basic auth, proxy and CA certs.

Closes #2

Request with all options configured proxied through mitmproxy
<img width="892" alt="Screenshot 2025-05-11 at 9 04 26 pm" src="https://github.com/user-attachments/assets/4a24aa98-4c8e-4325-b6ab-c85ddc249afb" />

