### PR TITLE
fix: docs, basic auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ cmp.setup({
           jenkins_url = "https://jenkins.co",
           gdsl_file = "~/.cache/nvim/cmp-jenkinsfile.gdsl",
           http = {
-            http_basic_user = "admin",
-            http_basic_password = "adminadmin",
+            basic_auth_user = "admin",
+            basic_auth_password = "adminadmin",
             ca_cert = "/etc/ssl/certs/cacert",
             proxy = "http://internal-proxy:8000",
           },

--- a/lua/cmp_jenkins/init.lua
+++ b/lua/cmp_jenkins/init.lua
@@ -33,7 +33,7 @@ local function build_curl(jenkins_url, opts)
         cmd = cmd.." --cacert "..opts.ca_cert
     end
     if opts.basic_auth_user ~= "" then
-        cmd = cmd.."--basic -u "..opts.basic_auth_user..":"..opts.basic_auth_password
+        cmd = cmd.." --basic --user "..opts.basic_auth_user..":"..opts.basic_auth_password
     end
     return cmd
 end


### PR DESCRIPTION
In the previous code, there is no space before the argument `--basic` has no space before.